### PR TITLE
feat: publish latest version of ceph image

### DIFF
--- a/rook/ceph/Makefile
+++ b/rook/ceph/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= rook/ceph
-SOURCE_IMAGE_VERSION ?= v1.14.2
+SOURCE_IMAGE_VERSION ?= v1.14.5
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/rook/ceph


### PR DESCRIPTION

Bumping the rook/ceph to latest version : rook/ceph:v1.14.5

Trivy report:

https://avd.aquasec.com/nvd/cve-2022-21797
https://avd.aquasec.com/nvd/cve-2024-24790  