### PR TITLE
feat: publish latest version of ceph image

### DIFF
--- a/ceph/ceph/Makefile
+++ b/ceph/ceph/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= quay.io/ceph/ceph
-SOURCE_IMAGE_VERSION ?= v18.2.2
+SOURCE_IMAGE_VERSION ?= v19.1
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/ceph/ceph

--- a/rook/ceph/Makefile
+++ b/rook/ceph/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= rook/ceph
-SOURCE_IMAGE_VERSION ?= v1.14.5
+SOURCE_IMAGE_VERSION ?= v1.14.8
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/rook/ceph


### PR DESCRIPTION
Bumping the rook/ceph to latest version : rook/ceph:v1.14.8

Trivy report:

https://avd.aquasec.com/nvd/cve-2024-24790

Updating latest ceph/ceph version to v19.1

