### PR TITLE
feat: publish latest version of ceph image

### DIFF
--- a/ceph/ceph/Makefile
+++ b/ceph/ceph/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= quay.io/ceph/ceph
-SOURCE_IMAGE_VERSION ?= v18.2.2
+SOURCE_IMAGE_VERSION ?= v19.1.0
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/ceph/ceph

--- a/rook/ceph/Makefile
+++ b/rook/ceph/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= rook/ceph
-SOURCE_IMAGE_VERSION ?= v1.14.5
+SOURCE_IMAGE_VERSION ?= v1.14.9
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/rook/ceph


### PR DESCRIPTION
Bumping the rook/ceph to latest version : rook/ceph:v1.14.9

Updating latest ceph/ceph version to v19.1.0

trivy report
https://avd.aquasec.com/nvd/cve-2024-24790

> sandhya.ravi@GT9X7CVF5F dkp-container-images % trivy i rook/ceph:v1.14.9 -s CRITICAL                                        
2024-08-22T12:51:24+05:30	INFO	Vulnerability scanning is enabled
2024-08-22T12:51:24+05:30	INFO	Secret scanning is enabled
2024-08-22T12:51:24+05:30	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-08-22T12:51:24+05:30	INFO	Please see also https://aquasecurity.github.io/trivy/v0.53/docs/scanner/secret#recommendation for faster secret detection
2024-08-22T12:51:27+05:30	INFO	Detected OS	family="none" version=""
2024-08-22T12:51:27+05:30	WARN	Unsupported os	family="none"
2024-08-22T12:51:27+05:30	INFO	Number of language-specific files	num=4
2024-08-22T12:51:27+05:30	INFO	[gobinary] Detecting vulnerabilities...
2024-08-22T12:51:27+05:30	INFO	[python-pkg] Detecting vulnerabilities...
2024-08-22T12:51:27+05:30	INFO	[node-pkg] Detecting vulnerabilities...
2024-08-22T12:51:27+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.53/docs/scanner/vulnerability#severity-selection for details.

usr/local/bin/s5cmd (gobinary)

Total: 1 (CRITICAL: 1)