### PR TITLE
chore:bump kube-oidc-proxy 1.0.9

### DIFF
--- a/kube-oidc-proxy/Makefile
+++ b/kube-oidc-proxy/Makefile
@@ -1,7 +1,7 @@
 BASE_IMAGE ?= gcr.io/distroless/static-debian12@sha256:69830f29ed7545c762777507426a412f97dad3d8d32bae3e74ad3fb6160917ea
 
 SOURCE_IMAGE_REPO ?= ghcr.io/tremolosecurity/kube-oidc-proxy
-SOURCE_IMAGE_VERSION ?= 1.0.7
+SOURCE_IMAGE_VERSION ?= 1.0.9
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/kube-oidc-proxy


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-105444

bump kube-oidc-proxy: bump to 1.0.9