### PR TITLE
build: old objectstorage-sidecar image

### DIFF
--- a/cosi/objectstorage-sidecar/Dockerfile
+++ b/cosi/objectstorage-sidecar/Dockerfile
@@ -5,5 +5,5 @@ ARG SOURCE_IMAGE
 
 FROM ${SOURCE_IMAGE}
 
-# Same ENTRYPOINT as in the SOURCE_IMAGE
-ENTRYPOINT ["/sidecar"]
+# Same ENTRYPOINT as in the SOURCE_IMAGE. This has been moved to /sidecar in latest versions.
+ENTRYPOINT ["/objectstorage-sidecar"]

--- a/cosi/objectstorage-sidecar/Makefile
+++ b/cosi/objectstorage-sidecar/Makefile
@@ -1,5 +1,5 @@
 SOURCE_IMAGE_REPO ?= gcr.io/k8s-staging-sig-storage/objectstorage-sidecar
-SOURCE_IMAGE_VERSION ?= v20250123-a0e4046
+SOURCE_IMAGE_VERSION ?= v20240513-v0.1.0-35-gefb3255 # This is the working version of the objectstorage-sidecar image for DKP 2.14.0 Ceph version. See https://github.com/ceph/ceph-cosi/issues/38 on why we cannot use the latest version.
 SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
 
 TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/objectstorage-sidecar


### PR DESCRIPTION
The latest image does not work for ceph -https://github.com/ceph/ceph-cosi/issues/38. So i decided to pin the image to whatever ceph in 2.14.0 uses - https://github.com/rook/rook/blob/v1.16.2/pkg/operator/ceph/object/cosi/spec.go#L30 

For nutanix driver, we can use the upstream image published yesterday https://github.com/kubernetes-sigs/container-object-storage-interface/releases/tag/v0.2.1