### PR TITLE
feat: Build a custom CNPG Postgres image with PGVector

### DIFF
--- a/cloudnative-pg/postgresql/Dockerfile
+++ b/cloudnative-pg/postgresql/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+ARG SOURCE_IMAGE
+
+FROM ${SOURCE_IMAGE}
+
+ARG PG_MAJOR_VERSION
+
+USER root
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends postgresql-${PG_MAJOR_VERSION}-pgvector && \
+    apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+USER postgres

--- a/cloudnative-pg/postgresql/Makefile
+++ b/cloudnative-pg/postgresql/Makefile
@@ -1,0 +1,22 @@
+SOURCE_IMAGE_REPO ?= ghcr.io/cloudnative-pg/postgresql
+SOURCE_IMAGE_VERSION ?= 17.4-minimal-bookworm
+SOURCE_IMAGE ?= $(SOURCE_IMAGE_REPO):$(SOURCE_IMAGE_VERSION)
+PG_MAJOR_VERSION ?= $(firstword $(subst ., ,$(SOURCE_IMAGE_VERSION)))
+
+TARGET_IMAGE_REPO ?= ghcr.io/mesosphere/dkp-container-images/cloudnative-pg/postgresql
+TARGET_IMAGE_VERSION ?= $(SOURCE_IMAGE_VERSION)
+TARGET_IMAGE ?= $(TARGET_IMAGE_REPO):$(TARGET_IMAGE_VERSION)
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(TARGET_IMAGE) \
+		--build-arg="SOURCE_IMAGE=$(SOURCE_IMAGE)" \
+		--build-arg="PG_MAJOR_VERSION=$(PG_MAJOR_VERSION)" \
+		$(CURDIR)
+
+.PHONY: build-args
+build-args:
+	@echo "SOURCE_IMAGE=$(SOURCE_IMAGE)"
+	@echo "PG_MAJOR_VERSION=$(PG_MAJOR_VERSION)"
+	@echo "TARGET_IMAGE=$(TARGET_IMAGE)"
+	@echo "TARGET_IMAGE_VERSION=$(TARGET_IMAGE_VERSION)"

--- a/cloudnative-pg/postgresql/README.md
+++ b/cloudnative-pg/postgresql/README.md
@@ -1,0 +1,11 @@
+# CNPG PostgreSQL Container Images
+
+A custom build of `ghcr.io/cloudnative-pg/postgresql` container image.
+Includes `pgvector` extension, which is not included by default in the upstream `minimal` image.
+The `minimal` flavour is used to reduce the amount of CVEs.
+
+## Build
+
+```shell
+make docker-build
+```


### PR DESCRIPTION
This pull request introduces a custom build process for a PostgreSQL container image with the `pgvector` extension. The changes include updates to the Dockerfile, Makefile, and README.md to support this custom build.

### Dockerfile changes:
* Added a new Dockerfile that uses an argument for the source image and installs the `pgvector` extension for PostgreSQL.

### Makefile changes:
* Added new targets to the Makefile for building the Docker image with specified arguments for source and target images.

### Documentation changes:
* Updated the README.md to include instructions for building the custom PostgreSQL container image using the Makefile.