### PR TITLE
ci: self-hosted-ncn-docker-medium machine not available

### DIFF
--- a/.github/workflows/create-publish-docaofed.yml
+++ b/.github/workflows/create-publish-docaofed.yml
@@ -43,7 +43,8 @@ on:
 jobs:
    create-publish-docaofed-driver:
     runs-on:
-      - self-hosted-ncn-docker-medium
+      - self-hosted
+      - small
     permissions:
       contents: read
       packages: write
@@ -59,6 +60,18 @@ jobs:
       with:
         enable-cache: true
         skip-nix-installation: true
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_READ_ONLY_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_READ_ONLY_PASSWORD }}
 
     - name: Login to GHCR
       uses: docker/login-action@v3


### PR DESCRIPTION
<img width="881" height="173" alt="Screenshot 2025-12-30 at 10 20 00 AM" src="https://github.com/user-attachments/assets/45f6cc59-106c-4538-8a44-f7e2d7bb227a" />

- self-hosted-ncn-docker-medium machine not available, changing it to use self-hosted or small machine