### PR TITLE
fix: Add a missing token, add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "10:00"

--- a/.github/workflows/build-from-source.yaml
+++ b/.github/workflows/build-from-source.yaml
@@ -71,6 +71,8 @@ jobs:
             IMAGE_VALUES=$(SOURCE_VERSION=${{ inputs.source-version }} make image-values)
             export $(echo "$IMAGE_VALUES" | xargs)
             echo "target_image=$TARGET_IMAGE" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build and push image
         id: build


### PR DESCRIPTION
The token was missing in the job definition.

Also, let's enable dependabot becase some actions are already ancient.
